### PR TITLE
fix: fixed error with tabs on LayoutBuilder rebuild

### DIFF
--- a/.github/workflows/equations_ci.yml
+++ b/.github/workflows/equations_ci.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - master
-      - develop
   pull_request:
     types:
       - opened
+      - ready_for_review
 
 jobs:
   verify_equation_package:

--- a/example/flutter_example/lib/routes/polynomial_page/polynomial_data_input.dart
+++ b/example/flutter_example/lib/routes/polynomial_page/polynomial_data_input.dart
@@ -149,54 +149,66 @@ class __InputWidget extends State<_InputWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        // Some space from the top
-        const SizedBox(height: 40),
+    return BlocListener<PolynomialBloc, PolynomialState>(
+      listener: (context, state) {
+        if (state is PolynomialError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(context.l10n.polynomial_error),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        }
+      },
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          // Some space from the top
+          const SizedBox(height: 40),
 
-        cachedEquationTitle,
+          cachedEquationTitle,
 
-        // Responsively placing input fields using 'Wrap'
-        Padding(
-          padding: const EdgeInsets.only(left: 60, right: 60),
-          child: Form(
-            key: formKey,
-            child: Wrap(
-              spacing: 30,
-              alignment: WrapAlignment.center,
-              children: cachedWrapBody,
+          // Responsively placing input fields using 'Wrap'
+          Padding(
+            padding: const EdgeInsets.only(left: 60, right: 60),
+            child: Form(
+              key: formKey,
+              child: Wrap(
+                spacing: 30,
+                alignment: WrapAlignment.center,
+                children: cachedWrapBody,
+              ),
             ),
           ),
-        ),
 
-        // A "spacer" widget
-        const SizedBox(height: 40),
+          // A "spacer" widget
+          const SizedBox(height: 40),
 
-        // Two buttons needed to "solve" and "clear" the equation
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            // Solving the polynomial
-            ElevatedButton(
-              key: const Key('Polynomial-button-solve'),
-              onPressed: () => _processInput(context),
-              child: Text(context.l10n.solve),
-            ),
+          // Two buttons needed to "solve" and "clear" the equation
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Solving the polynomial
+              ElevatedButton(
+                key: const Key('Polynomial-button-solve'),
+                onPressed: () => _processInput(context),
+                child: Text(context.l10n.solve),
+              ),
 
-            // Some spacing
-            const SizedBox(width: 30),
+              // Some spacing
+              const SizedBox(width: 30),
 
-            // Cleaning the inputs
-            ElevatedButton(
-              key: const Key('Polynomial-button-clean'),
-              onPressed: () => _cleanInput(context),
-              child: Text(context.l10n.clean),
-            ),
-          ],
-        )
-      ],
+              // Cleaning the inputs
+              ElevatedButton(
+                key: const Key('Polynomial-button-clean'),
+                onPressed: () => _cleanInput(context),
+                child: Text(context.l10n.clean),
+              ),
+            ],
+          )
+        ],
+      ),
     );
   }
 }

--- a/example/flutter_example/lib/routes/polynomial_page/polynomial_results.dart
+++ b/example/flutter_example/lib/routes/polynomial_page/polynomial_results.dart
@@ -113,17 +113,7 @@ class __PolynomialDiscriminantState extends State<_PolynomialDiscriminant> {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 30),
-      child: BlocConsumer<PolynomialBloc, PolynomialState>(
-        listener: (context, state) {
-          if (state is PolynomialError) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(context.l10n.polynomial_error),
-                duration: const Duration(seconds: 2),
-              ),
-            );
-          }
-        },
+      child: BlocBuilder<PolynomialBloc, PolynomialState>(
         builder: (context, state) {
           if (state is PolynomialRoots) {
             return ComplexResultCard(

--- a/example/flutter_example/lib/routes/utils/equation_scaffold.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold.dart
@@ -19,7 +19,7 @@ const _assertionError = 'There must be at least 1 navigation item.';
 ///
 /// This widget also contains a responsive navigation bar which can be either a
 /// [BottomNavigationBar] or a [NavigationRail] according with the screen's size.
-class EquationScaffold extends StatelessWidget {
+class EquationScaffold extends StatefulWidget {
   /// The body of the [Scaffold]. When there's a [navigationItems] list defined,
   /// this widget is ignored because the actual body of the scaffold will be
   /// determined by the contents of the list.
@@ -51,16 +51,34 @@ class EquationScaffold extends StatelessWidget {
         );
 
   @override
+  _EquationScaffoldState createState() => _EquationScaffoldState();
+}
+
+class _EquationScaffoldState extends State<EquationScaffold> with SingleTickerProviderStateMixin {
+  /// Controls the position of the currently visible page of the [TabBarView].
+  late final tabController = TabController(
+    length: widget.navigationItems.length,
+    vsync: this,
+  );
+
+  @override
+  void dispose() {
+    tabController.dispose();
+
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     // If there are NO navigation items, then no navigation bars are required
-    if (navigationItems.isEmpty) {
+    if (widget.navigationItems.isEmpty) {
       return LayoutBuilder(
         builder: (context, dimensions) => Scaffold(
           body: _ScaffoldContents(
-            body: body,
+            body: widget.body,
             extraBackground: dimensions.maxWidth >= 1300,
           ),
-          floatingActionButton: fab,
+          floatingActionButton: widget.fab,
         ),
       );
     }
@@ -80,14 +98,15 @@ class EquationScaffold extends StatelessWidget {
               key: const Key('TabbedNavigationLayout-Scaffold'),
               body: _ScaffoldContents(
                 body: TabbedNavigationLayout(
-                  navigationItems: navigationItems,
+                  navigationItems: widget.navigationItems,
+                  tabController: tabController,
                 ),
                 extraBackground: hasExtraBackground,
               ),
               bottomNavigationBar: BottomNavigation(
-                navigationItems: navigationItems,
+                navigationItems: widget.navigationItems,
               ),
-              floatingActionButton: fab,
+              floatingActionButton: widget.fab,
             );
           }
 
@@ -95,11 +114,12 @@ class EquationScaffold extends StatelessWidget {
             key: const Key('RailNavigationLayout-Scaffold'),
             body: _ScaffoldContents(
               body: RailNavigation(
-                navigationItems: navigationItems,
+                navigationItems: widget.navigationItems,
+                tabController: tabController,
               ),
               extraBackground: hasExtraBackground,
             ),
-            floatingActionButton: fab,
+            floatingActionButton: widget.fab,
           );
         },
       ),

--- a/example/flutter_example/lib/routes/utils/equation_scaffold.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold.dart
@@ -54,7 +54,8 @@ class EquationScaffold extends StatefulWidget {
   _EquationScaffoldState createState() => _EquationScaffoldState();
 }
 
-class _EquationScaffoldState extends State<EquationScaffold> with SingleTickerProviderStateMixin {
+class _EquationScaffoldState extends State<EquationScaffold>
+    with SingleTickerProviderStateMixin {
   /// Controls the position of the currently visible page of the [TabBarView].
   late final tabController = TabController(
     length: widget.navigationItems.length,

--- a/example/flutter_example/lib/routes/utils/equation_scaffold/rail_navigation.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold/rail_navigation.dart
@@ -25,7 +25,8 @@ class RailNavigation extends StatefulWidget {
 
 class _RailNavigationState extends State<RailNavigation> {
   /// Converts a [NavigationItem] into a [BottomNavigationBarItem].
-  late final rails = widget.navigationItems.map<NavigationRailDestination>((item) {
+  late final rails =
+      widget.navigationItems.map<NavigationRailDestination>((item) {
     return NavigationRailDestination(
       icon: item.icon,
       selectedIcon: item.activeIcon,

--- a/example/flutter_example/lib/routes/utils/equation_scaffold/rail_navigation.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold/rail_navigation.dart
@@ -10,9 +10,13 @@ class RailNavigation extends StatefulWidget {
   /// A list of items for a responsive navigation bar.
   final List<NavigationItem> navigationItems;
 
+  /// Controls the position of the currently visible page of the [TabBarView].
+  final TabController tabController;
+
   /// Creates a [RailNavigation] widget..
   const RailNavigation({
     required this.navigationItems,
+    required this.tabController,
   });
 
   @override
@@ -21,8 +25,7 @@ class RailNavigation extends StatefulWidget {
 
 class _RailNavigationState extends State<RailNavigation> {
   /// Converts a [NavigationItem] into a [BottomNavigationBarItem].
-  late final rails =
-      widget.navigationItems.map<NavigationRailDestination>((item) {
+  late final rails = widget.navigationItems.map<NavigationRailDestination>((item) {
     return NavigationRailDestination(
       icon: item.icon,
       selectedIcon: item.activeIcon,
@@ -38,6 +41,7 @@ class _RailNavigationState extends State<RailNavigation> {
         Expanded(
           child: TabbedNavigationLayout(
             navigationItems: widget.navigationItems,
+            tabController: widget.tabController,
           ),
         ),
 

--- a/example/flutter_example/lib/routes/utils/equation_scaffold/tabbed_layout.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold/tabbed_layout.dart
@@ -32,7 +32,6 @@ class TabbedNavigationLayoutState extends State<TabbedNavigationLayout> {
       .map((item) => item.content)
       .toList(growable: false);
 
-
   /// Changes the currently visible page of the tab.
   void changePage(int pageIndex) => widget.tabController.animateTo(pageIndex);
 

--- a/example/flutter_example/lib/routes/utils/equation_scaffold/tabbed_layout.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold/tabbed_layout.dart
@@ -11,9 +11,13 @@ class TabbedNavigationLayout extends StatefulWidget {
   /// A list of items for a responsive navigation bar.
   final List<NavigationItem> navigationItems;
 
+  /// Controls the position of the currently visible page of the [TabBarView].
+  final TabController tabController;
+
   /// Creates a [TabbedNavigationLayout] widget.
   const TabbedNavigationLayout({
     required this.navigationItems,
+    required this.tabController,
   });
 
   @override
@@ -22,34 +26,15 @@ class TabbedNavigationLayout extends StatefulWidget {
 
 /// The state of the [TabbedNavigationLayout] widget.
 @visibleForTesting
-class TabbedNavigationLayoutState extends State<TabbedNavigationLayout>
-    with SingleTickerProviderStateMixin {
-  /// Controls the position of the currently visible page of the [TabBarView].
-  late final TabController tabController;
-
+class TabbedNavigationLayoutState extends State<TabbedNavigationLayout> {
   /// The various pages of the [TabBarView].
   late final tabPages = widget.navigationItems
       .map((item) => item.content)
       .toList(growable: false);
 
-  @override
-  void initState() {
-    super.initState();
-
-    tabController = TabController(
-      length: widget.navigationItems.length,
-      vsync: this,
-    );
-  }
-
-  @override
-  void dispose() {
-    tabController.dispose();
-    super.dispose();
-  }
 
   /// Changes the currently visible page of the tab.
-  void changePage(int pageIndex) => tabController.animateTo(pageIndex);
+  void changePage(int pageIndex) => widget.tabController.animateTo(pageIndex);
 
   @override
   Widget build(BuildContext context) {
@@ -58,7 +43,7 @@ class TabbedNavigationLayoutState extends State<TabbedNavigationLayout>
       listener: (context, state) => changePage(state),
       child: TabBarView(
         physics: const NeverScrollableScrollPhysics(),
-        controller: tabController,
+        controller: widget.tabController,
         children: tabPages,
       ),
     );

--- a/example/flutter_example/test/routes/utils/equation_scaffold/rail_navigation_test.dart
+++ b/example/flutter_example/test/routes/utils/equation_scaffold/rail_navigation_test.dart
@@ -9,13 +9,23 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../mock_wrapper.dart';
 
 void main() {
+  late final TabController controller;
+
+  setUpAll(() {
+    controller = TabController(
+      length: 2,
+      vsync: const TestVSync(),
+    );
+  });
+
   group("Testing the 'RailNavigation' widget", () {
     testWidgets('Making sure that the widget can be rendered', (tester) async {
       await tester.pumpWidget(MockWrapper(
         child: BlocProvider<NavigationCubit>(
           create: (_) => NavigationCubit(),
-          child: const RailNavigation(
-            navigationItems: [
+          child: RailNavigation(
+            tabController: controller,
+            navigationItems: const [
               NavigationItem(
                 title: 'Test',
                 content: SizedBox(),

--- a/example/flutter_example/test/routes/utils/equation_scaffold/tabbed_navigation_test.dart
+++ b/example/flutter_example/test/routes/utils/equation_scaffold/tabbed_navigation_test.dart
@@ -17,7 +17,6 @@ void main() {
     );
   });
 
-
   group("Testing the 'TabbedNavigationLayout' widget", () {
     testWidgets('Making sure that the widget can be rendered', (tester) async {
       await tester.pumpWidget(MockWrapper(
@@ -47,41 +46,41 @@ void main() {
     });
 
     testWidgets('Making sure that tabs can be changed with a controller',
-            (tester) async {
-          await tester.pumpWidget(MockWrapper(
-            child: BlocProvider<NavigationCubit>(
-              create: (_) => NavigationCubit(),
-              child: TabbedNavigationLayout(
-                tabController: controller,
-                navigationItems: const [
-                  NavigationItem(
-                    title: 'Test',
-                    content: Text('A'),
-                  ),
-                  NavigationItem(
-                    title: 'Test',
-                    content: Text('B'),
-                  ),
-                ],
+        (tester) async {
+      await tester.pumpWidget(MockWrapper(
+        child: BlocProvider<NavigationCubit>(
+          create: (_) => NavigationCubit(),
+          child: TabbedNavigationLayout(
+            tabController: controller,
+            navigationItems: const [
+              NavigationItem(
+                title: 'Test',
+                content: Text('A'),
               ),
-            ),
-          ));
+              NavigationItem(
+                title: 'Test',
+                content: Text('B'),
+              ),
+            ],
+          ),
+        ),
+      ));
 
-          final finder = find.byType(TabbedNavigationLayout);
-          final state = tester.state(finder) as TabbedNavigationLayoutState;
+      final finder = find.byType(TabbedNavigationLayout);
+      final state = tester.state(finder) as TabbedNavigationLayoutState;
 
-          // Start at 0
-          expect(controller.index, isZero);
-          expect(find.text('A'), findsOneWidget);
-          expect(find.text('B'), findsNothing);
+      // Start at 0
+      expect(controller.index, isZero);
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsNothing);
 
-          // Changing the page
-          state.changePage(1);
-          await tester.pumpAndSettle();
+      // Changing the page
+      state.changePage(1);
+      await tester.pumpAndSettle();
 
-          expect(controller.index, equals(1));
-          expect(find.text('B'), findsOneWidget);
-          expect(find.text('A'), findsNothing);
-        });
+      expect(controller.index, equals(1));
+      expect(find.text('B'), findsOneWidget);
+      expect(find.text('A'), findsNothing);
+    });
   });
 }

--- a/example/flutter_example/test/routes/utils/equation_scaffold/tabbed_navigation_test.dart
+++ b/example/flutter_example/test/routes/utils/equation_scaffold/tabbed_navigation_test.dart
@@ -8,13 +8,24 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../mock_wrapper.dart';
 
 void main() {
+  late final TabController controller;
+
+  setUpAll(() {
+    controller = TabController(
+      length: 2,
+      vsync: const TestVSync(),
+    );
+  });
+
+
   group("Testing the 'TabbedNavigationLayout' widget", () {
     testWidgets('Making sure that the widget can be rendered', (tester) async {
       await tester.pumpWidget(MockWrapper(
         child: BlocProvider<NavigationCubit>(
           create: (_) => NavigationCubit(),
-          child: const TabbedNavigationLayout(
-            navigationItems: [
+          child: TabbedNavigationLayout(
+            tabController: controller,
+            navigationItems: const [
               NavigationItem(
                 title: 'Test',
                 content: SizedBox(),
@@ -36,40 +47,41 @@ void main() {
     });
 
     testWidgets('Making sure that tabs can be changed with a controller',
-        (tester) async {
-      await tester.pumpWidget(MockWrapper(
-        child: BlocProvider<NavigationCubit>(
-          create: (_) => NavigationCubit(),
-          child: const TabbedNavigationLayout(
-            navigationItems: [
-              NavigationItem(
-                title: 'Test',
-                content: Text('A'),
+            (tester) async {
+          await tester.pumpWidget(MockWrapper(
+            child: BlocProvider<NavigationCubit>(
+              create: (_) => NavigationCubit(),
+              child: TabbedNavigationLayout(
+                tabController: controller,
+                navigationItems: const [
+                  NavigationItem(
+                    title: 'Test',
+                    content: Text('A'),
+                  ),
+                  NavigationItem(
+                    title: 'Test',
+                    content: Text('B'),
+                  ),
+                ],
               ),
-              NavigationItem(
-                title: 'Test',
-                content: Text('B'),
-              ),
-            ],
-          ),
-        ),
-      ));
+            ),
+          ));
 
-      final finder = find.byType(TabbedNavigationLayout);
-      final state = tester.state(finder) as TabbedNavigationLayoutState;
+          final finder = find.byType(TabbedNavigationLayout);
+          final state = tester.state(finder) as TabbedNavigationLayoutState;
 
-      // Start at 0
-      expect(state.tabController.index, isZero);
-      expect(find.text('A'), findsOneWidget);
-      expect(find.text('B'), findsNothing);
+          // Start at 0
+          expect(controller.index, isZero);
+          expect(find.text('A'), findsOneWidget);
+          expect(find.text('B'), findsNothing);
 
-      // Changing the page
-      state.changePage(1);
-      await tester.pumpAndSettle();
+          // Changing the page
+          state.changePage(1);
+          await tester.pumpAndSettle();
 
-      expect(state.tabController.index, equals(1));
-      expect(find.text('B'), findsOneWidget);
-      expect(find.text('A'), findsNothing);
-    });
+          expect(controller.index, equals(1));
+          expect(find.text('B'), findsOneWidget);
+          expect(find.text('A'), findsNothing);
+        });
   });
 }


### PR DESCRIPTION
## Why?

When resizing the page on web (but also on mobile & desktop) the `TabController` is rebuilt and so it's always set back to 0. The current position is not persisted.

## What?

I have moved the `TabController` one widget above the `LayoutBuilder` so that the position (ie. the current controller index) is stored in the state and not lost during a rebuild on `LayoutBuilder`.

## Types of Changes

 - Bug fix (non-breaking change which fixes an issue)

## Notes

n/a

## Checklist

- [x] I have provided a description of the proposed changes.
- [x] I added unit tests for all relevant code.
- [ ] I added golden tests for all UI changes.
- [ ] I added documentation for all relevant code.
