### PR TITLE
fix: fixed tab controller persistence

### DIFF
--- a/example/flutter_example/lib/routes/polynomial_page/polynomial_body.dart
+++ b/example/flutter_example/lib/routes/polynomial_page/polynomial_body.dart
@@ -153,6 +153,11 @@ class __PolynomialPlotState extends State<_PolynomialPlot> {
           child: SingleChildScrollView(
             child: Column(
               children: [
+                // Some spacing
+                const SizedBox(
+                  height: 50,
+                ),
+
                 // Title
                 SectionTitle(
                   pageTitle: context.l10n.chart,

--- a/example/flutter_example/lib/routes/utils/equation_scaffold.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold.dart
@@ -19,7 +19,7 @@ const _assertionError = 'There must be at least 1 navigation item.';
 ///
 /// This widget also contains a responsive navigation bar which can be either a
 /// [BottomNavigationBar] or a [NavigationRail] according with the screen's size.
-class EquationScaffold extends StatelessWidget {
+class EquationScaffold extends StatefulWidget {
   /// The body of the [Scaffold]. When there's a [navigationItems] list defined,
   /// this widget is ignored because the actual body of the scaffold will be
   /// determined by the contents of the list.
@@ -51,16 +51,35 @@ class EquationScaffold extends StatelessWidget {
         );
 
   @override
+  _EquationScaffoldState createState() => _EquationScaffoldState();
+}
+
+class _EquationScaffoldState extends State<EquationScaffold>
+    with SingleTickerProviderStateMixin {
+  /// Controls the position of the currently visible page.
+  late final tabController = TabController(
+    length: widget.navigationItems.length,
+    vsync: this,
+  );
+
+  @override
+  void dispose() {
+    tabController.dispose();
+
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     // If there are NO navigation items, then no navigation bars are required
-    if (navigationItems.isEmpty) {
+    if (widget.navigationItems.isEmpty) {
       return LayoutBuilder(
         builder: (context, dimensions) => Scaffold(
           body: _ScaffoldContents(
-            body: body,
+            body: widget.body,
             extraBackground: dimensions.maxWidth >= 1300,
           ),
-          floatingActionButton: fab,
+          floatingActionButton: widget.fab,
         ),
       );
     }
@@ -80,14 +99,15 @@ class EquationScaffold extends StatelessWidget {
               key: const Key('TabbedNavigationLayout-Scaffold'),
               body: _ScaffoldContents(
                 body: TabbedNavigationLayout(
-                  navigationItems: navigationItems,
+                  tabController: tabController,
+                  navigationItems: widget.navigationItems,
                 ),
                 extraBackground: hasExtraBackground,
               ),
               bottomNavigationBar: BottomNavigation(
-                navigationItems: navigationItems,
+                navigationItems: widget.navigationItems,
               ),
-              floatingActionButton: fab,
+              floatingActionButton: widget.fab,
             );
           }
 
@@ -95,11 +115,12 @@ class EquationScaffold extends StatelessWidget {
             key: const Key('RailNavigationLayout-Scaffold'),
             body: _ScaffoldContents(
               body: RailNavigation(
-                navigationItems: navigationItems,
+                tabController: tabController,
+                navigationItems: widget.navigationItems,
               ),
               extraBackground: hasExtraBackground,
             ),
-            floatingActionButton: fab,
+            floatingActionButton: widget.fab,
           );
         },
       ),

--- a/example/flutter_example/lib/routes/utils/equation_scaffold/rail_navigation.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold/rail_navigation.dart
@@ -10,9 +10,13 @@ class RailNavigation extends StatefulWidget {
   /// A list of items for a responsive navigation bar.
   final List<NavigationItem> navigationItems;
 
+  /// Controls the position of the currently visible page on the screen.
+  final TabController tabController;
+
   /// Creates a [RailNavigation] widget..
   const RailNavigation({
     required this.navigationItems,
+    required this.tabController,
   });
 
   @override
@@ -38,6 +42,7 @@ class _RailNavigationState extends State<RailNavigation> {
         Expanded(
           child: TabbedNavigationLayout(
             navigationItems: widget.navigationItems,
+            tabController: widget.tabController,
           ),
         ),
 

--- a/example/flutter_example/lib/routes/utils/equation_scaffold/tabbed_layout.dart
+++ b/example/flutter_example/lib/routes/utils/equation_scaffold/tabbed_layout.dart
@@ -11,9 +11,13 @@ class TabbedNavigationLayout extends StatefulWidget {
   /// A list of items for a responsive navigation bar.
   final List<NavigationItem> navigationItems;
 
+  /// Controls the position of the currently visible page on the screen.
+  final TabController tabController;
+
   /// Creates a [TabbedNavigationLayout] widget.
   const TabbedNavigationLayout({
     required this.navigationItems,
+    required this.tabController,
   });
 
   @override
@@ -22,34 +26,14 @@ class TabbedNavigationLayout extends StatefulWidget {
 
 /// The state of the [TabbedNavigationLayout] widget.
 @visibleForTesting
-class TabbedNavigationLayoutState extends State<TabbedNavigationLayout>
-    with SingleTickerProviderStateMixin {
-  /// Controls the position of the currently visible page of the [TabBarView].
-  late final TabController tabController;
-
+class TabbedNavigationLayoutState extends State<TabbedNavigationLayout> {
   /// The various pages of the [TabBarView].
   late final tabPages = widget.navigationItems
       .map((item) => item.content)
       .toList(growable: false);
 
-  @override
-  void initState() {
-    super.initState();
-
-    tabController = TabController(
-      length: widget.navigationItems.length,
-      vsync: this,
-    );
-  }
-
-  @override
-  void dispose() {
-    tabController.dispose();
-    super.dispose();
-  }
-
   /// Changes the currently visible page of the tab.
-  void changePage(int pageIndex) => tabController.animateTo(pageIndex);
+  void changePage(int pageIndex) => widget.tabController.animateTo(pageIndex);
 
   @override
   Widget build(BuildContext context) {
@@ -58,7 +42,7 @@ class TabbedNavigationLayoutState extends State<TabbedNavigationLayout>
       listener: (context, state) => changePage(state),
       child: TabBarView(
         physics: const NeverScrollableScrollPhysics(),
-        controller: tabController,
+        controller: widget.tabController,
         children: tabPages,
       ),
     );

--- a/example/flutter_example/test/routes/utils/equation_scaffold/rail_navigation_test.dart
+++ b/example/flutter_example/test/routes/utils/equation_scaffold/rail_navigation_test.dart
@@ -9,13 +9,23 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../mock_wrapper.dart';
 
 void main() {
+  late final TabController controller;
+
+  setUpAll(() {
+    controller = TabController(
+      length: 2,
+      vsync: const TestVSync(),
+    );
+  });
+
   group("Testing the 'RailNavigation' widget", () {
     testWidgets('Making sure that the widget can be rendered', (tester) async {
       await tester.pumpWidget(MockWrapper(
         child: BlocProvider<NavigationCubit>(
           create: (_) => NavigationCubit(),
-          child: const RailNavigation(
-            navigationItems: [
+          child: RailNavigation(
+            tabController: controller,
+            navigationItems: const [
               NavigationItem(
                 title: 'Test',
                 content: SizedBox(),

--- a/example/flutter_example/test/routes/utils/equation_scaffold/tabbed_navigation_test.dart
+++ b/example/flutter_example/test/routes/utils/equation_scaffold/tabbed_navigation_test.dart
@@ -8,13 +8,23 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../mock_wrapper.dart';
 
 void main() {
+  late final TabController controller;
+
+  setUpAll(() {
+    controller = TabController(
+      length: 2,
+      vsync: const TestVSync(),
+    );
+  });
+
   group("Testing the 'TabbedNavigationLayout' widget", () {
     testWidgets('Making sure that the widget can be rendered', (tester) async {
       await tester.pumpWidget(MockWrapper(
         child: BlocProvider<NavigationCubit>(
           create: (_) => NavigationCubit(),
-          child: const TabbedNavigationLayout(
-            navigationItems: [
+          child: TabbedNavigationLayout(
+            tabController: controller,
+            navigationItems: const [
               NavigationItem(
                 title: 'Test',
                 content: SizedBox(),
@@ -40,8 +50,9 @@ void main() {
       await tester.pumpWidget(MockWrapper(
         child: BlocProvider<NavigationCubit>(
           create: (_) => NavigationCubit(),
-          child: const TabbedNavigationLayout(
-            navigationItems: [
+          child: TabbedNavigationLayout(
+            tabController: controller,
+            navigationItems: const [
               NavigationItem(
                 title: 'Test',
                 content: Text('A'),
@@ -59,7 +70,7 @@ void main() {
       final state = tester.state(finder) as TabbedNavigationLayoutState;
 
       // Start at 0
-      expect(state.tabController.index, isZero);
+      expect(controller.index, isZero);
       expect(find.text('A'), findsOneWidget);
       expect(find.text('B'), findsNothing);
 
@@ -67,7 +78,7 @@ void main() {
       state.changePage(1);
       await tester.pumpAndSettle();
 
-      expect(state.tabController.index, equals(1));
+      expect(controller.index, equals(1));
       expect(find.text('B'), findsOneWidget);
       expect(find.text('A'), findsNothing);
     });


### PR DESCRIPTION
## Why?

When resizing the page on web (but also on mobile & desktop) the `TabController` is rebuilt and so it's always set back to 0. The current position is not persisted.

## What?

I have moved the `TabController` one widget above the `LayoutBuilder` so that the position (ie. the current controller index) is stored in the state and not lost during a rebuild on `LayoutBuilder`.

## Types of Changes

 - Bug fix (non-breaking change which fixes an issue)

## Notes

n/a

## Checklist

- [x] I have provided a description of the proposed changes.
- [x] I added unit tests for all relevant code.
- [ ] I added golden tests for all UI changes.
- [ ] I added documentation for all relevant code.
