### PR TITLE
insert evenSum at even guesses indices

### DIFF
--- a/lib/src/integral/types/simpson_rule.dart
+++ b/lib/src/integral/types/simpson_rule.dart
@@ -50,7 +50,7 @@ class SimpsonRule extends NumericalIntegration {
     // The second iteration.
     for (var i = 2; i < intervals - 1; i += 2) {
       evenSum += evaluateFunction(lowerBound + i * h);
-      guesses[i] = oddSum;
+      guesses[i] = evenSum;
     }
 
     // Returning the result.


### PR DESCRIPTION
## Why?

All even indices of guesses were filled with the last calculation of oddSum. 

## What?

Insert evenSum (The calculation of the even entries) in Simpson's Rule, into the even indices of guesses.

## Types of Changes

<!-- Uncomment the type(s) that matches the changes in this Pull Request. -->

<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!-- - Documentation change (change to update documentation) -->
- General improvements (quality updates to improve the stability of the project) 

## Notes

<!--- If appropriate, provide some additional notes relevant to the PR. --->

## Checklist

- [x] I have provided a description of the proposed changes.
- [ ] I added unit tests for all relevant code.
- [ ] In `example/flutter_example`, if needed, I have also added widget and golden tests.
- [ ] I added documentation for all relevant code.
