### PR TITLE
chore: CI update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,11 +11,7 @@ assignees: albertodev01
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+Steps to reproduce the behavior
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,5 +24,4 @@
 
 - [ ] I have provided a description of the proposed changes.
 - [ ] I added unit tests for all relevant code.
-- [ ] In `example/flutter_example`, if needed, I have also added widget and golden tests.
 - [ ] I added documentation for all relevant code.

--- a/.github/workflows/documentation_web_deploy.yml
+++ b/.github/workflows/documentation_web_deploy.yml
@@ -1,6 +1,10 @@
 name: documentation_web_deploy
 
 on:
+  # Manually run the workflow from the GitHub Actions UI with the
+  # 'Run workflow' button.
+  workflow_dispatch:
+
   push:
     branches:
       - master
@@ -9,6 +13,8 @@ jobs:
   documentation_deployment:
     name: HTML Documentation deployment
     runs-on: macos-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why?

CI hasn't published the latest `dart doc` output to github pages

## What?

 - Added a manual dispatch trigger
 - Added write permissions

## Types of Changes

- General improvements (quality updates to improve the stability of the project)

## Notes

n/a

## Checklist

- [x] I have provided a description of the proposed changes.
- [x] I added unit tests for all relevant code.
- [ ] I added documentation for all relevant code.
